### PR TITLE
Fix building on x86 with -DDISABLE_CPU_OPTIMIZE=ON

### DIFF
--- a/contrib/fastops-cmake/CMakeLists.txt
+++ b/contrib/fastops-cmake/CMakeLists.txt
@@ -2,15 +2,11 @@ set(LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/fastops)
 
 set(SRCS "")
 
-if(HAVE_AVX)
-    set (SRCS ${SRCS} ${LIBRARY_DIR}/fastops/avx/ops_avx.cpp)
-    set_source_files_properties(${LIBRARY_DIR}/fastops/avx/ops_avx.cpp PROPERTIES COMPILE_FLAGS "-mavx -DNO_AVX2")
-endif()
+set (SRCS ${SRCS} ${LIBRARY_DIR}/fastops/avx/ops_avx.cpp)
+set_source_files_properties(${LIBRARY_DIR}/fastops/avx/ops_avx.cpp PROPERTIES COMPILE_FLAGS "-mavx -DNO_AVX2")
 
-if(HAVE_AVX2)
-    set (SRCS ${SRCS} ${LIBRARY_DIR}/fastops/avx2/ops_avx2.cpp)
-    set_source_files_properties(${LIBRARY_DIR}/fastops/avx2/ops_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma")
-endif()
+set (SRCS ${SRCS} ${LIBRARY_DIR}/fastops/avx2/ops_avx2.cpp)
+set_source_files_properties(${LIBRARY_DIR}/fastops/avx2/ops_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma")
 
 set (SRCS ${SRCS} ${LIBRARY_DIR}/fastops/plain/ops_plain.cpp ${LIBRARY_DIR}/fastops/core/avx_id.cpp ${LIBRARY_DIR}/fastops/fastops.cpp)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix undefined symbol errors on x86 with -DDISABLE_CPU_OPTIMIZE=ON
...


Detailed description / Documentation draft:
When building with -DDISABLE_CPU_OPTIMIZE=ON on x86 (e.g. when targeting also CPUs without AVX/AVX2), undefined symbol errors to functions such as LogAvx and LogAvx2 show up.
This is because the source files containing these functions, are left out.
They should be included, because this library (fastops) does runtime-checks using the cpuid instruction, and only if the processor supports AVX/AVX2, it'll use these versions.
Also, packagers should probably use  -DDISABLE_CPU_OPTIMIZE=ON, to prevent the compiler from generating AVX/AVX2 instructions, leading to illegal instruction crashes on x86 processors without AVX/AVX2
...

Log snippet:
```
ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<false, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:13 (../contrib/fastops/fastops/fastops.cpp:13)
>>>               lto.tmp:(void NFastOps::Exp<false, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<false, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:15 (../contrib/fastops/fastops/fastops.cpp:15)
>>>               lto.tmp:(void NFastOps::Exp<false, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<false, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:13 (../contrib/fastops/fastops/fastops.cpp:13)
>>>               lto.tmp:(void NFastOps::Exp<false, true>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<false, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:15 (../contrib/fastops/fastops/fastops.cpp:15)
>>>               lto.tmp:(void NFastOps::Exp<false, true>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<true, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:13 (../contrib/fastops/fastops/fastops.cpp:13)
>>>               lto.tmp:(void NFastOps::Exp<true, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<true, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:15 (../contrib/fastops/fastops/fastops.cpp:15)
>>>               lto.tmp:(void NFastOps::Exp<true, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<true, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:13 (../contrib/fastops/fastops/fastops.cpp:13)
>>>               lto.tmp:(void NFastOps::Exp<true, true>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<true, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:15 (../contrib/fastops/fastops/fastops.cpp:15)
>>>               lto.tmp:(void NFastOps::Exp<true, true>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<false, false>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:24 (../contrib/fastops/fastops/fastops.cpp:24)
>>>               lto.tmp:(void NFastOps::Exp<false, false>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<false, false>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:26 (../contrib/fastops/fastops/fastops.cpp:26)
>>>               lto.tmp:(void NFastOps::Exp<false, false>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<false, true>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:24 (../contrib/fastops/fastops/fastops.cpp:24)
>>>               lto.tmp:(void NFastOps::Exp<false, true>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<false, true>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:26 (../contrib/fastops/fastops/fastops.cpp:26)
>>>               lto.tmp:(void NFastOps::Exp<false, true>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<true, false>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:24 (../contrib/fastops/fastops/fastops.cpp:24)
>>>               lto.tmp:(void NFastOps::Exp<true, false>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<true, false>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:26 (../contrib/fastops/fastops/fastops.cpp:26)
>>>               lto.tmp:(void NFastOps::Exp<true, false>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx2<true, true>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:24 (../contrib/fastops/fastops/fastops.cpp:24)
>>>               lto.tmp:(void NFastOps::Exp<true, true>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::ExpAvx<true, true>(double const*, unsigned long, double*)
>>> referenced by fastops.cpp:26 (../contrib/fastops/fastops/fastops.cpp:26)
>>>               lto.tmp:(void NFastOps::Exp<true, true>(double const*, unsigned long, double*))

ld.lld: error: undefined symbol: void NFastOps::LogAvx2<false, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:35 (../contrib/fastops/fastops/fastops.cpp:35)
>>>               lto.tmp:(void NFastOps::Log<false, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::LogAvx<false, false>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:37 (../contrib/fastops/fastops/fastops.cpp:37)
>>>               lto.tmp:(void NFastOps::Log<false, false>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::LogAvx2<false, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:35 (../contrib/fastops/fastops/fastops.cpp:35)
>>>               lto.tmp:(void NFastOps::Log<false, true>(float const*, unsigned long, float*))

ld.lld: error: undefined symbol: void NFastOps::LogAvx<false, true>(float const*, unsigned long, float*)
>>> referenced by fastops.cpp:37 (../contrib/fastops/fastops/fastops.cpp:37)
>>>               lto.tmp:(void NFastOps::Log<false, true>(float const*, unsigned long, float*))

ld.lld: error: too many errors emitted, stopping now (use -error-limit=0 to see all errors)
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```